### PR TITLE
Add Java 21 Swagger API example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Maven
+target/
+*.log
+
+# IDE
+.idea/
+*.iml

--- a/helloworld-api/README.md
+++ b/helloworld-api/README.md
@@ -1,0 +1,20 @@
+# HelloWorld API
+
+Simple Spring Boot API running on Java 21. Provides `/hello` endpoint returning
+`helloworld` string. It includes Swagger UI via `springdoc-openapi` and adds the
+JDBI dependency for future database integration.
+
+## Build
+
+```bash
+mvn package
+```
+
+## Run
+
+```bash
+mvn spring-boot:run
+```
+
+Swagger UI will be available at `http://localhost:8080/swagger-ui.html` once the
+application is running.

--- a/helloworld-api/pom.xml
+++ b/helloworld-api/pom.xml
@@ -1,0 +1,40 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>helloworld-api</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+    </properties>
+    <dependencies>
+        <!-- Spring Boot dependencies -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <version>3.3.0</version>
+        </dependency>
+        <!-- springdoc OpenAPI for Swagger UI -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.5.0</version>
+        </dependency>
+        <!-- JDBI dependency -->
+        <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-core</artifactId>
+            <version>3.45.0</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>3.3.0</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/helloworld-api/src/main/java/com/example/hello/Application.java
+++ b/helloworld-api/src/main/java/com/example/hello/Application.java
@@ -1,0 +1,11 @@
+package com.example.hello;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+}

--- a/helloworld-api/src/main/java/com/example/hello/HelloController.java
+++ b/helloworld-api/src/main/java/com/example/hello/HelloController.java
@@ -1,0 +1,13 @@
+package com.example.hello;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloController {
+
+    @GetMapping("/hello")
+    public String hello() {
+        return "helloworld";
+    }
+}


### PR DESCRIPTION
## Summary
- create basic Spring Boot API returning `helloworld`
- enable Swagger UI using springdoc-openapi
- include JDBI dependency for future DB integration

## Testing
- `mvn package` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_684b23c5b6e883298a0ef40ee4298e67